### PR TITLE
bugfix on RecipeList, MyPage

### DIFF
--- a/frontend/src/components/UserInfo/SimpleUserInfo.js
+++ b/frontend/src/components/UserInfo/SimpleUserInfo.js
@@ -7,14 +7,8 @@ const SimpleUserInfo = (props) => {
             <div id='showuser' className = 'username'>
             {'username:\u00A0\u00A0\u00A0'+props.username}
             </div>
-            <div id='showuser' className = 'first_name'>
-            {props.first_name}
-            </div>
-            <div id='showuser' className = 'last_name'>
-            {props.last_name}
-            </div>
             <div  id='showuser' className = 'email'>
-            {props.email}
+            {'email:\u00A0\u00A0\u00A0'+props.email}
             </div>
         </div>
     );
@@ -22,8 +16,6 @@ const SimpleUserInfo = (props) => {
 
 SimpleUserInfo.propTypes = {
     username: PropTypes.string,
-    first_name: PropTypes.string,
-    last_name: PropTypes.string,
     email: PropTypes.string,
 };
 

--- a/frontend/src/containers/Authentication/Login/Login.js
+++ b/frontend/src/containers/Authentication/Login/Login.js
@@ -41,7 +41,7 @@ class Login extends Component{
                     <div className="Login" >
                         <label>RECIPICK</label>
                         <input type="text" name="id"  placeholder = "아이디" onChange={(event) => this.setState({id: event.target.value})}></input>
-                        <input type="text" name="password" placeholder = "비밀번호" onChange={(event) => this.setState({password: event.target.value})}></input>
+                        <input type="text" name="password" placeholder = "비밀번호" onChange={(event) => this.setState({password: event.target.value})} type="password"></input>
                         <button className="LoginButton" onClick={()=>this.onClickSubmit()}>로그인</button>
                     </div>
                 </div>

--- a/frontend/src/containers/Authentication/Signup/Signup.js
+++ b/frontend/src/containers/Authentication/Signup/Signup.js
@@ -45,14 +45,12 @@ class Signup extends Component{
                         <p> RECIPICK </p>
                         <label>이름</label>
                         <input type="text" name="name" onChange={(event) => this.setState({name: event.target.value})}></input>
-                        <label>비밀번호</label>
-                        <input type="text" name="id" onChange={(event) => this.setState({id: event.target.value})}></input>
                         <label>이메일</label>
                         <input type="text" name="email" onChange={(event) => this.setState({email: event.target.value})}></input>
                         <label>비밀번호</label>
-                        <input type="text" name="password" onChange={(event) => this.setState({password: event.target.value})}></input>
+                        <input type="text" name="password" type="password" onChange={(event) => this.setState({password: event.target.value})}></input>
                         <label>비밀번호 재확인</label>
-                        <input type="text" name="password_confirm" onChange={(event) => this.setState({password_confirm: event.target.value})}></input>
+                        <input type="text" name="password_confirm" type="password" onChange={(event) => this.setState({password_confirm: event.target.value})}></input>
                     </form>
                     <button className = "SignupButton" onClick={()=>this.onClickSubmit()}>가입하기</button>
                 </div>

--- a/frontend/src/containers/MyInfo/MyInfo.js
+++ b/frontend/src/containers/MyInfo/MyInfo.js
@@ -34,25 +34,17 @@ class MyInfo extends Component{
                         <p id='infolabel'>Username</p>
                         {'\u00A0'.repeat(33)+this.props.username}
                         </div>
-                        <div  className = "first_name">
-                        <p id='infolabel'>first name</p>
-                        {'\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0'+this.props.first_name}
-                        </div>
-                        <div  className = "last_name">
-                        <p id='infolabel'>last name</p>
-                        {'\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0'+this.props.last_name}
-                        </div>
                         <div  className = "email">
                         <p id='infolabel'>email</p>
                         {'\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0'+this.props.email}
                         </div>
                         <p id='infolabel'>new password</p>
                         {'\u00A0'.repeat(26)}
-                        <input type="text" className="new_password"  placeholder = "새 비밀번호" onChange={(event) => this.setState({new_password: event.target.value})}></input>
+                        <input type="text" className="new_password" type="password" placeholder = "새 비밀번호" onChange={(event) => this.setState({new_password: event.target.value})}></input>
                         <br/>
                         <p id='infolabel' >new password(confirm)</p>
                         {'\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0'}
-                        <input type="text" className="password_confirm" placeholder = "비밀번호 확인" onChange={(event) => this.setState({password_confirm: event.target.value})}></input>
+                        <input type="text" className="password_confirm" type="password" placeholder = "비밀번호 확인" onChange={(event) => this.setState({password_confirm: event.target.value})}></input>
                         <button className="changePassword" disabled = {!this.state.new_password || !this.state.password_confirm} onClick={()=>this.onClickSubmit()}>비밀번호 변경</button>
                     </form>
                 </div>

--- a/frontend/src/containers/RecipeList/RecipeList.js
+++ b/frontend/src/containers/RecipeList/RecipeList.js
@@ -122,10 +122,23 @@ class RecipeList extends Component{
 
     checkInputHandler = (state) =>{
         let st=state;
-        if(this.state.maxPrice == '') st.maxPrice=100000;
-        if(this.state.minPrice == '') st.minPrice=0;
-        if(this.state.maxDuration == '') st.maxDuration=100;
-        if(this.state.minDuration == '') st.minDuration=0;
+        let tempMaxPrice, tempMinPrice;
+        let tempMaxDuration, tempMinDuration;
+        let message = '';
+        tempMaxPrice = parseInt(st.maxPrice);
+        tempMinPrice = parseInt(st.minPrice);
+        tempMaxDuration = parseInt(st.maxDuration);
+        tempMinDuration = parseInt(st.minDuration);
+        if(isNaN(tempMaxPrice)) message += "가격의 상한을 올바르게 입력하세요.\n";
+        if(isNaN(tempMinPrice)) message += "가격의 하한을 올바르게 입력하세요.\n";
+        if(isNaN(tempMaxDuration)) message += "조리 시간의 상한을 올바르게 입력하세요.\n";
+        if(isNaN(tempMinDuration)) message += "조리 시간의 하한을 올바르게 입력하세요.\n";
+
+        if(message){
+            window.alert(message);
+            return null;
+        }
+        
         return st;
     }
 
@@ -140,13 +153,15 @@ class RecipeList extends Component{
 
     clickSearchHandler = () => {
         let newSearchSettings=this.checkInputHandler({...this.state.tempSearchSettings, pageNumber: 1});
-        this.setState(prevState => ({
-            ...prevState,
-            SearchSettings: newSearchSettings,
-        }));
-        this.props.history.push(this.getURL(newSearchSettings));
-        this.props.onGetRecipes(newSearchSettings);
-        window.location.reload();
+        if(newSearchSettings){
+            this.setState(prevState => ({
+                ...prevState,
+                SearchSettings: newSearchSettings,
+            }));
+            this.props.history.push(this.getURL(newSearchSettings));
+            this.props.onGetRecipes(newSearchSettings);
+            window.location.reload();
+        }   
     }
 
     clickPagePreviousHandler = () => {


### PR DESCRIPTION
RecipeList:
input handling => 가격이나 조리 시간에 숫자가 아닌 다른 걸 입력하고 confirm을 누르면 alert가 뜨면서 서치가 되는 것을 방지함.

MyPage:
myinfo에서 의미없는 field 삭제
비밀번호 안 보이게 하는거(Login, Signup 페이지에도 이건 일괄 적용시킴)


지금 생각나는 고쳐야되는거:  written recipes tab에서 레시피들이 아래로 나열되는게 아니라 오른쪽으로 나열돼서 보는게 좀 이상해짐
아래로 쭉 나열할 수 없으면 검색할 때처럼 페이지를 만들어야 할 듯...?